### PR TITLE
Update is_dockerized to use docker-check

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,6 +1,7 @@
 pyaml
 gunicorn
 django
+docker-check
 dpath
 python-consul
 redis

--- a/setup.py
+++ b/setup.py
@@ -29,5 +29,12 @@ setup(
         'Programming Language :: Python :: 3.7',
         'License :: OSI Approved :: MIT License',
     ],
-    install_requires=['dpath', 'pyaml', 'gunicorn', 'django', 'terminaltables']
+    install_requires=[
+        'django',
+        'docker-check',
+        'dpath',
+        'gunicorn',
+        'pyaml',
+        'terminaltables',
+    ]
 )


### PR DESCRIPTION
docker-check is only used as a fallback, allowing
an environ variable to improve performance or fudge
result.

Closes https://github.com/night-crawler/django-docker-helpers/issues/5